### PR TITLE
Added a more XSS proof method of generating breadcrumbs

### DIFF
--- a/dynamic_breadcrumbs/context_processors.py
+++ b/dynamic_breadcrumbs/context_processors.py
@@ -5,6 +5,9 @@ def breadcrumbs(request):
     """
     Add breadcrumbs dict to the context.
     """
-    base_url = request.build_absolute_uri("/")
-    breadcrumbs = Breadcrumbs(base_url=base_url, path=request.path)
-    return {"breadcrumbs": breadcrumbs.as_list()}
+    breadcrumbs = Breadcrumbs(base_url=request.build_absolute_uri('/'), path=request.path)
+
+    # Return a dictionary with the breadcrumbs data
+    return {
+        'breadcrumbs': breadcrumbs.as_list()
+    }

--- a/dynamic_breadcrumbs/utils.py
+++ b/dynamic_breadcrumbs/utils.py
@@ -85,6 +85,10 @@ class Breadcrumbs:
 
     def validate_path(self, path):
         """Validate the path to ensure it matches an expected pattern and is within allowed limits."""
+        if not isinstance(path, str):
+            logger.warning("Invalid path type provided: %s", type(path))
+            return ""
+
         # Ensure the path contains only alphanumeric characters, dashes, underscores, and slashes
         if not re.match(r'^[a-zA-Z0-9_\-/]*$', path):
             logger.warning("Invalid path provided: %s", path)
@@ -103,6 +107,7 @@ class Breadcrumbs:
                 return ""
 
         return path
+
 
 
 class BreadcrumbsItem:


### PR DESCRIPTION
We've observed that when special characters are introduced into the URL, they are directly reflected in the breadcrumbs. For instance, using the XSS polyglot highlights this behavior.
```
jaVasCript:/*-/*`/*\`/*'/*"/**/(/* */oNcliCk=alert() )//%0D%0A%0d%0a//</stYle/</titLe/</teXtarEa/</scRipt/--!>\x3csVg/<sVg/oNloAd=alert()//>\x3e
```

This poses a risk as it simplifies the exploitation of XSS vulnerabilities. To address this, we've made modifications to our code to enhance its resistance against XSS attacks. We've implemented a temporary monkeypatch to bolster our defenses against such threats. We kindly request a review of our updated code, and if deemed appropriate, its integration and release to fortify the security for all users.

